### PR TITLE
Switch to sassc-rails.

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,3 @@
-appraise "sass-3-4" do
-  gem "sass", "~> 3.4"
-end
-
 appraise "rails42" do
   gem "actionpack", "~> 4.2.0"
   gem "actionview", "~> 4.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       jquery-rails (>= 4.0)
       kaminari (>= 1.0)
       momentjs-rails (~> 2.8)
-      sass-rails (~> 5.0)
+      sassc-rails (~> 1.3)
       selectize-rails (~> 0.6)
 
 GEM
@@ -97,7 +97,7 @@ GEM
       i18n (>= 0.7)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     formulaic (0.4.0)
       activesupport
       capybara
@@ -206,18 +206,22 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     safe_yaml (1.0.4)
-    sass (3.5.6)
+    sass (3.5.7)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
-    selectize-rails (0.12.4.1)
+    sassc (1.12.1)
+      ffi (~> 1.9.6)
+      sass (>= 3.3.0)
+    sassc-rails (1.3.0)
+      railties (>= 4.0.0)
+      sass
+      sassc (~> 1.9)
+      sprockets (> 2.11)
+      sprockets-rails
+      tilt
+    selectize-rails (0.12.5)
     sentry-raven (2.7.2)
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (3.1.2)
@@ -290,4 +294,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/administrate.gemspec
+++ b/administrate.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails", ">= 4.0"
   s.add_dependency "kaminari", ">= 1.0"
   s.add_dependency "momentjs-rails", "~> 2.8"
-  s.add_dependency "sass-rails", "~> 5.0"
+  s.add_dependency "sassc-rails", "~> 1.3"
   s.add_dependency "selectize-rails", "~> 0.6"
 
   s.description = <<-DESCRIPTION

--- a/lib/administrate/engine.rb
+++ b/lib/administrate/engine.rb
@@ -2,7 +2,7 @@ require "datetime_picker_rails"
 require "jquery-rails"
 require "kaminari"
 require "momentjs-rails"
-require "sass-rails"
+require "sassc-rails"
 require "selectize-rails"
 require "sprockets/railtie"
 


### PR DESCRIPTION
Ruby Sass will reach end of life on 26th Match 2019. This switches to
`sassc-rails` and drops the appraisal for Sass 3.4.

Currently, `sassc-rails` still has `sass` as a dependency hence this is still
included in the `Gemfile.lock`.

See: https://github.com/rails/sass-rails/issues/420

Fixes #1196.